### PR TITLE
Ding seo event news landingpages

### DIFF
--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -194,17 +194,14 @@ function ding_event_install_menu_position($op = 'install') {
  */
 function ding_event_views_pre_execute(&$view) {
   if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list'))) {
-    // Skip for term_view page. The BEF filter is not used here.
-    if ($view->args) {
-      return;
-    }
     $view->build_info['query']->groupBy('node.nid');
     $view->build_info['count_query']->groupBy('node.nid');
   }
 
   // Handle the "show_all" type of events, so they filter by end date instead of
   // start date.
-  if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list', 'ding_event_list_frontpage'))) {
+  if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list', 'ding_event_list_frontpage'))
+    && in_array(current_path(), array('ding_frontpage', 'arrangementer'))) {
     // Add the field_ding_event_list_filter field, so it can be used in the
     // filter.
     $view->build_info['query']->leftJoin(

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -194,6 +194,10 @@ function ding_event_install_menu_position($op = 'install') {
  */
 function ding_event_views_pre_execute(&$view) {
   if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list'))) {
+    // Skip for term_view page. The BEF filter is not used here.
+    if ($view->args) {
+      return;
+    }
     $view->build_info['query']->groupBy('node.nid');
     $view->build_info['count_query']->groupBy('node.nid');
   }

--- a/modules/ding_event/ding_event.pages_default.inc
+++ b/modules/ding_event/ding_event.pages_default.inc
@@ -489,6 +489,31 @@ taxonomy/term/%term:tid',
     $pane->uuid = '3cb95651-0650-42f1-a8bd-e56688d1a4aa';
     $display->content['new-3cb95651-0650-42f1-a8bd-e56688d1a4aa'] = $pane;
     $display->panels['main_content'][0] = 'new-3cb95651-0650-42f1-a8bd-e56688d1a4aa';
+    $pane = new stdClass();
+    $pane->pid = 'new-1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a';
+    $pane->panel = 'main_content';
+    $pane->type = 'entity_field_extra';
+    $pane->subtype = 'taxonomy_term:description';
+    $pane->shown = TRUE;
+    $pane->access = array();
+    $pane->configuration = array(
+      'view_mode' => 'full',
+      'context' => 'argument_term_1',
+      'override_title' => 0,
+      'override_title_text' => '',
+      'override_title_heading' => 'h2',
+    );
+    $pane->cache = array();
+    $pane->style = array(
+      'settings' => NULL,
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = 1;
+    $pane->locks = array();
+    $pane->uuid = '1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a';
+    $display->content['new-1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a'] = $pane;
+    $display->panels['main_content'][1] = 'new-1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;

--- a/modules/ding_news/ding_news.pages_default.inc
+++ b/modules/ding_news/ding_news.pages_default.inc
@@ -736,6 +736,31 @@ taxonomy/term/%term:tid',
     $pane->uuid = '26d16112-d9b0-4d46-8192-b301259f9e3c';
     $display->content['new-26d16112-d9b0-4d46-8192-b301259f9e3c'] = $pane;
     $display->panels['main_content'][0] = 'new-26d16112-d9b0-4d46-8192-b301259f9e3c';
+    $pane = new stdClass();
+    $pane->pid = 'new-e1d496c2-f35c-4e13-b043-646e7146b9a1';
+    $pane->panel = 'main_content';
+    $pane->type = 'entity_field_extra';
+    $pane->subtype = 'taxonomy_term:description';
+    $pane->shown = TRUE;
+    $pane->access = array();
+    $pane->configuration = array(
+      'view_mode' => 'full',
+      'context' => 'argument_term_1',
+      'override_title' => 0,
+      'override_title_text' => '',
+      'override_title_heading' => 'h2',
+    );
+    $pane->cache = array();
+    $pane->style = array(
+      'settings' => NULL,
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = 1;
+    $pane->locks = array();
+    $pane->uuid = 'e1d496c2-f35c-4e13-b043-646e7146b9a1';
+    $display->content['new-e1d496c2-f35c-4e13-b043-646e7146b9a1'] = $pane;
+    $display->panels['main_content'][1] = 'new-e1d496c2-f35c-4e13-b043-646e7146b9a1';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = 'new-26d16112-d9b0-4d46-8192-b301259f9e3c';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
Very basic solution that displays term description on the event and news panel of term_view page.

The solution will have limited SEO impact because news list and event lists don't link to the category term pages any more. Thus Google won't find them and index them.

The problem:
All filtering on the news and events pages is provided in a large combined ajax BEF filter. Filtering by category doesn't reload the page, it's all on the same page. 

Consideration:
I think it is outside the scope of this project to change the filtering options on the event and news pages. There will be many different opinions on this issue, and it will take a lot of time and effort to convince non-SEO-people that the nice AJAX filters are a bad solution. I think most people like them.