### PR TITLE
5150: Undo changes to ding_event and ding_news

### DIFF
--- a/modules/ding_event/ding_event.features.field_instance.inc
+++ b/modules/ding_event/ding_event.features.field_instance.inc
@@ -177,7 +177,7 @@ function ding_event_field_default_field_instances() {
         'label' => 'hidden',
         'module' => 'taxonomy',
         'settings' => array(),
-        'type' => 'taxonomy_term_reference_link',
+        'type' => 'taxonomy_term_reference_plain',
         'weight' => 1,
       ),
       'rss' => array(

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -195,8 +195,7 @@ function ding_event_views_query_alter(&$view, &$query) {
   // also consider the end date. Under normal circumstances this could all be
   // set up in views, but we need this work with the exposed filters on the
   // ding_event_list also.
-  if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list', 'ding_event_list_frontpage'))
-    && in_array(current_path(), array('ding_frontpage', 'arrangementer'))) {
+  if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list', 'ding_event_list_frontpage'))) {
     $join = new views_join();
     $join->construct('field_data_field_ding_event_list_filter', 'node', 'nid', 'entity_id');
     $join->extra = [

--- a/modules/ding_event/ding_event.pages_default.inc
+++ b/modules/ding_event/ding_event.pages_default.inc
@@ -582,31 +582,6 @@ taxonomy/term/%term:tid',
     $pane->uuid = '3cb95651-0650-42f1-a8bd-e56688d1a4aa';
     $display->content['new-3cb95651-0650-42f1-a8bd-e56688d1a4aa'] = $pane;
     $display->panels['main_content'][0] = 'new-3cb95651-0650-42f1-a8bd-e56688d1a4aa';
-    $pane = new stdClass();
-    $pane->pid = 'new-1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a';
-    $pane->panel = 'main_content';
-    $pane->type = 'entity_field_extra';
-    $pane->subtype = 'taxonomy_term:description';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'view_mode' => 'full',
-      'context' => 'argument_term_1',
-      'override_title' => 0,
-      'override_title_text' => '',
-      'override_title_heading' => 'h2',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 1;
-    $pane->locks = array();
-    $pane->uuid = '1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a';
-    $display->content['new-1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a'] = $pane;
-    $display->panels['main_content'][1] = 'new-1a4f7e2a-fbbd-4c23-a2ff-3fc222aff66a';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;

--- a/modules/ding_news/ding_news.pages_default.inc
+++ b/modules/ding_news/ding_news.pages_default.inc
@@ -736,31 +736,6 @@ taxonomy/term/%term:tid',
     $pane->uuid = '26d16112-d9b0-4d46-8192-b301259f9e3c';
     $display->content['new-26d16112-d9b0-4d46-8192-b301259f9e3c'] = $pane;
     $display->panels['main_content'][0] = 'new-26d16112-d9b0-4d46-8192-b301259f9e3c';
-    $pane = new stdClass();
-    $pane->pid = 'new-e1d496c2-f35c-4e13-b043-646e7146b9a1';
-    $pane->panel = 'main_content';
-    $pane->type = 'entity_field_extra';
-    $pane->subtype = 'taxonomy_term:description';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'view_mode' => 'full',
-      'context' => 'argument_term_1',
-      'override_title' => 0,
-      'override_title_text' => '',
-      'override_title_heading' => 'h2',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 1;
-    $pane->locks = array();
-    $pane->uuid = 'e1d496c2-f35c-4e13-b043-646e7146b9a1';
-    $display->content['new-e1d496c2-f35c-4e13-b043-646e7146b9a1'] = $pane;
-    $display->panels['main_content'][1] = 'new-e1d496c2-f35c-4e13-b043-646e7146b9a1';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = 'new-26d16112-d9b0-4d46-8192-b301259f9e3c';
   $handler->conf['display'] = $display;


### PR DESCRIPTION
#### Description

I have decided to revert all changes to ding_event and ding_news. By using sections the same SEO effects can be achieved.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
